### PR TITLE
additional options for controlling simID and the main output file

### DIFF
--- a/MatFilesInit/initiateOutParameters.m
+++ b/MatFilesInit/initiateOutParameters.m
@@ -20,26 +20,36 @@ s = what(outParams.outputFolder);
 outParams.outputFolder = s.path;
 fprintf('Full path of the output folder = %s\n',outParams.outputFolder);
 
-% Name of the file that summarizes the inputs and outputs of the simulation
-% Each simulation adds a line in append
-% The file is a xls file
-% The name of the file cannot be changed
-outParams.outMainFile = 'MainOut.xls';
-fprintf('Main output file = %s/%s\n',outParams.outputFolder,outParams.outMainFile);
 
-% Simulation ID
-mainFileName = sprintf('%s/%s',outParams.outputFolder,outParams.outMainFile);
-fid = fopen(mainFileName);
-if fid==-1
-    simID = 0;
+% [printToXLSMainFile]
+[outParams,varargin]= addNewParam(outParams,'printToXLSMainFile', true, 'Write some result info into a main xls file','bool',fileCfg,varargin{1});
+if outParams.printToXLSMainFile
+    % Name of the file that summarizes the inputs and outputs of the simulation
+    % Each simulation adds a line in append
+    % The file is a xls file
+    % The name of the file cannot be changed
+    [outParams,varargin]= addNewParam(outParams,'outMainFile','MainOut.xls','Output Main File','string',fileCfg,varargin{1});
+    fprintf('Main output file = %s/%s\n',outParams.outputFolder,outParams.outMainFile);
+    % Simulation ID
+    [outParams,varargin]= addNewParam(outParams,'simID',0,'Sim ID - leave 0 for auto increment from main file','integer',fileCfg,varargin{1});
+    if outParams.simID == 0
+        mainFileName = sprintf('%s/%s',outParams.outputFolder,outParams.outMainFile);
+        fid = fopen(mainFileName);
+        if fid==-1
+            simID = 0;
+        else
+            % use recommended function textscan
+            C = textscan(fid,'%s %*[^\n]');
+            simID = str2double(C{1}{end});
+            fclose(fid);
+        end
+        outParams.simID = simID+1;
+    end
+    fprintf('Simulation ID = %.0f\n',outParams.simID);
 else
-    % use recommended function textscan
-    C = textscan(fid,'%s %*[^\n]');
-    simID = str2double(C{1}{end});
-    fclose(fid);
+    % Simulation ID
+    [outParams,varargin]= addNewParam(outParams,'simID',1,'Sim ID - default 1 if printToXLSMainFile','integer',fileCfg,varargin{1});
 end
-outParams.simID = simID+1;
-fprintf('Simulation ID = %.0f\n',outParams.simID);
 
 % [printNeighbors]
 % Boolean to activate the print to file of the number of neighbors
@@ -164,4 +174,5 @@ end
 [outParams,varargin]= addNewParam(outParams,'message', 'None', 'Message during simulation','string',fileCfg,varargin{1});
 fprintf('\n');
 %
+
 %%%%%%%%%

--- a/MatFilesInit/initiateOutParameters.m
+++ b/MatFilesInit/initiateOutParameters.m
@@ -30,20 +30,27 @@ if outParams.printToXLSMainFile
     % The name of the file cannot be changed
     [outParams,varargin]= addNewParam(outParams,'outMainFile','MainOut.xls','Output Main File','string',fileCfg,varargin{1});
     fprintf('Main output file = %s/%s\n',outParams.outputFolder,outParams.outMainFile);
-    % Simulation ID
+    
+    % Two ways to use the "parfor"
+    % 1. Using different output folder.
+    % 2. At the same output folder, the simID should be set one by one 
+    %    before starting simulation.
+    % Note: with the 2nd method, if not set simID before the simulation,
+    % there might be some errors multiple processes have the same
+    % simID
     [outParams,varargin]= addNewParam(outParams,'simID',0,'Sim ID - leave 0 for auto increment from main file','integer',fileCfg,varargin{1});
-    if outParams.simID == 0
-        mainFileName = sprintf('%s/%s',outParams.outputFolder,outParams.outMainFile);
-        fid = fopen(mainFileName);
-        if fid==-1
-            simID = 0;
+    if outParams.simID == 0     % fixme: auto increment does not support parallel tasks. The IDs would be a mess
+        mainFileName = fullfile(outParams.outputFolder, outParams.outMainFile);
+        if exist(mainFileName, "file") ~= 2
+            outParams.simID = 1;
         else
+            fid = fopen(mainFileName);
             % use recommended function textscan
             C = textscan(fid,'%s %*[^\n]');
             simID = str2double(C{1}{end});
+            outParams.simID = simID+1;
             fclose(fid);
         end
-        outParams.simID = simID+1;
     end
     fprintf('Simulation ID = %.0f\n',outParams.simID);
 else

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Alessandro Bazzi (alessandro.bazzi@unibo.it)
 
 Vittorio Todisco (vittorio.todisco@unibo.it, vittorio.todisco@ieiit.cnr.it)
 
-Wu Zhuofei, also called Felix (wu.zhuofei@unibo.it)
+Wu Zhuofei, also called Felix (wzfhrb.cn@gmail.com)
 *****
 
 *****

--- a/WiLabV2Xsim.m
+++ b/WiLabV2Xsim.m
@@ -376,7 +376,9 @@ if outParams.printHiddenNodeProb
 end
 
 % Print to XLS file
-outputToFiles(stationManagement,simParams,appParams,phyParams,sinrManagement,outParams,outputValues);
+if outParams.printToXLSMainFile
+    outputToFiles(stationManagement,simParams,appParams,phyParams,sinrManagement,outParams,outputValues);
+end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Print To Video


### PR DESCRIPTION
Hi V2Xsim maintainers,

The purpose of this pull request is to add additional options to control whether the application writes the summary of results to `MainOut.xls`, in addition to being able to control the name. There is also the option to manually specify the `simID` -  if not specified, it will use the old logic of auto incrementing (if printing to main out is disabled, defaults to simID 1)

The motivation behind this is to enable parallelism such as running many simulations at once using `parfeval` or `parfor`. If you want to call `WiLabV2Xsim.m` in a parallel environment, the original behavior of trying to auto increment the ID will cause a race condition between the processes. In such cases, it is much more conducive to prepopulate a list of sim IDs depending on the research question being investigated, and have each simulation not write over each others' files because they might complete at different times.