### PR TITLE
make the main function return output and used params

### DIFF
--- a/WiLabV2Xsim.m
+++ b/WiLabV2Xsim.m
@@ -1,4 +1,4 @@
-function WiLabV2Xsim(varargin)
+function [outputValues, allParams] = WiLabV2Xsim(varargin)
 % The function WiLabV2Xsim() is the main function of the simulator
 
 % ==============
@@ -76,6 +76,13 @@ end
 
 % Update PHY structure with the ranges
 [phyParams] = deriveRanges(phyParams,simParams);
+
+% Save all the params to return later
+allParams = struct();
+allParams.simParams = simParams;
+allParams.appParams = appParams;
+allParams.phyParams = phyParams;
+allParams.outParams = outParams;
 
 % Simulator output inizialization
 outputValues = struct('computationTime',-1,...


### PR DESCRIPTION
This PR makes the main `WiLabV2Xsim` entrypoint return the outputValues and also a struct containing all the populated params. This is to enable easier saving and caching of experiment results when programmatically calling the simulator in batch (for example, to do parameter sweeps)