### PR TITLE
add support for counting hidden node events, and add unit tests

### DIFF
--- a/MainFilesCV2X/updateKPICV2X.m
+++ b/MainFilesCV2X/updateKPICV2X.m
@@ -83,7 +83,11 @@ for iPhyRaw=1:length(phyParams.Raw)
     if simParams.typeOfScenario==constants.SCENARIO_TRACE && outParams.printPRRmap
         simValues = counterMap(iPhyRaw,simValues,stationManagement.activeIDsCV2X,indexInActiveIDsOnlyLTE,activeIDsTXLTE,awarenessID_LTE(:,:,iPhyRaw),errorMatrix);
     end
-
+    
+    if outParams.printHiddenNodeEvents
+        hiddenNodeEvents = countHiddenNodeEvents(errorRxList=errorRxList, awarenessIDLTE=stationManagement.awarenessIDLTE(:,:,iPhyRaw), BRid=stationManagement.BRid, NbeaconsT=appParams.NbeaconsT, duplexCV2X=phyParams.duplexCV2X);
+        outputValues.hiddenNodeEvents(iPhyRaw) = outputValues.hiddenNodeEvents(iPhyRaw) + hiddenNodeEvents;
+    end
 end
 
 % Count distance details for distances up to the maximum awareness range (if enabled)

--- a/MatFilesInit/initiateOutParameters.m
+++ b/MatFilesInit/initiateOutParameters.m
@@ -163,5 +163,8 @@ end
 % [message]
 [outParams,varargin]= addNewParam(outParams,'message', 'None', 'Message during simulation','string',fileCfg,varargin{1});
 fprintf('\n');
-%
+
+% [printHiddenNodeEvents]
+[outParams,varargin] = addNewParam(outParams,'printHiddenNodeEvents', false, 'Count the number of errors due to hidden node problem', 'bool', fileCfg, varargin{1});
+
 %%%%%%%%%

--- a/MatFilesOut/countHiddenNodeEvents.m
+++ b/MatFilesOut/countHiddenNodeEvents.m
@@ -1,0 +1,30 @@
+function hiddenNodeEvents = countHiddenNodeEvents(args)
+    arguments
+        args.errorRxList (:, 5) double
+        args.awarenessIDLTE (:, :) double {mustBeInteger}
+        args.BRid (1, :) double {mustBeInteger}
+        args.NbeaconsT double {mustBeInteger}
+        args.duplexCV2X string
+    end
+    errorRxList = args.errorRxList;
+    hiddenNodeEvents = 0;
+    for error_rx_list_i = 1:size(errorRxList, 1)
+        tx = errorRxList(error_rx_list_i, 1);
+        rx = errorRxList(error_rx_list_i, 2);
+        tx_brid = errorRxList(error_rx_list_i, 3);
+        % Find who else is within rx's awareness range
+        rx_neighbors = setdiff(nonzeros(args.awarenessIDLTE(rx,:)), tx);
+        if args.duplexCV2X == "HD"
+            % If half duplex, the interferers are the rx's neighbors
+            % using the same BRT
+            tx_bridT = mod(tx_brid, args.NbeaconsT);
+            ix = rx_neighbors(mod(args.BRid(rx_neighbors), args.NbeaconsT) == tx_bridT);
+        else
+            % If full duplex, the interferers are the rx's neighbors
+            % using the exact same BR
+            ix = rx_neighbors(args.BRid(rx_neighbors) == tx_brid);
+        end
+        % If the ix is not within tx's awareness range, is hidden node
+        hiddenNodeEvents = hiddenNodeEvents + nnz(~ismember(ix, args.awarenessIDLTE(tx, :)));
+    end
+end

--- a/MatFilesOut/printHiddenNodeEvents.m
+++ b/MatFilesOut/printHiddenNodeEvents.m
@@ -1,0 +1,17 @@
+function [] = printHiddenNodeEvents(args)
+    % Prints the hiddenNodeEvents member (of the outputValue struct) to a
+    % csv file
+    % Format is just n rows of events, each row corresponds to number of
+    % events counted in a specified awareness range
+    arguments
+        args.outputFolder string
+        args.simId (1, 1) double
+        args.hiddenNodeEvents (:, 1) double
+    end
+    base_filename = sprintf("hiddennode-%d.csv", args.simId);
+    outputFolder = args.outputFolder;
+    if isfolder(outputFolder) == false
+        mkdir(outputFolder)
+    end
+    writematrix(args.hiddenNodeEvents, sprintf('%s/%s', outputFolder, base_filename));
+end

--- a/Tests/+v2xsim_tests/+unit/+out/test_countHiddenNodeEvents.m
+++ b/Tests/+v2xsim_tests/+unit/+out/test_countHiddenNodeEvents.m
@@ -60,7 +60,7 @@ awarenessIDLTE = [
 % 1 and 3 share the same BRT and same BRF, don't care about 2
 BRid = [9 -1 9];
 NbeaconsT = 3;
-actual = countHiddenNodeEvents(errorRxList=errorRxList, awarenessIDLTE=awarenessIDLTE, BRid=BRid, NbeaconsT=NbeaconsT, duplexCV2X="HD");
+actual = countHiddenNodeEvents(errorRxList=errorRxList, awarenessIDLTE=awarenessIDLTE, BRid=BRid, NbeaconsT=NbeaconsT, duplexCV2X="FD");
 expected = 1;
 verifyEqual(testCase, actual, expected);
 end

--- a/Tests/+v2xsim_tests/+unit/+out/test_countHiddenNodeEvents.m
+++ b/Tests/+v2xsim_tests/+unit/+out/test_countHiddenNodeEvents.m
@@ -1,0 +1,66 @@
+function tests = test_countHiddenNodeEvents
+tests = functiontests(localfunctions);
+end
+
+function testSimpleCaseHDSameBRF(testCase)
+% test the simple case in HD mode where there is only one BRF
+% let 1 be tx, 2 be rx, 3 be interferer
+% let the BRid in contention be 9
+errorRxList = [1 2 9 100 0];
+% 1 can see 2, cannot see 3
+% 2 can see 1 and 3
+% 3 can only see 2
+awarenessIDLTE = [
+    2 0 0;
+    1 3 0;
+    2 0 0;
+    ];
+% 1 and 3 share the same BR, don't care about 2
+BRid = [9 -1 9];
+actual = countHiddenNodeEvents(errorRxList=errorRxList, awarenessIDLTE=awarenessIDLTE, BRid=BRid, NbeaconsT=100, duplexCV2X="HD");
+expected = 1;
+verifyEqual(testCase, actual, expected);
+end
+
+function testCaseHDSameBRTDiffBRF(testCase)
+% a slightly more complex case, test if the tx and ix are in the same BRT,
+% even if diff BRF, in HD mode we consider this hidden node
+% let 1 be tx, 2 be rx, 3 be interferer
+% let the BRid in contention be 9
+errorRxList = [1 2 9 100 0];
+% 1 can see 2, cannot see 3
+% 2 can see 1 and 3
+% 3 can only see 2
+awarenessIDLTE = [
+    2 0 0;
+    1 3 0;
+    2 0 0;
+    ];
+% 1 and 3 share the same BRT but diff BRF, don't care about 2
+BRid = [3 -1 9];
+NbeaconsT = 3;
+actual = countHiddenNodeEvents(errorRxList=errorRxList, awarenessIDLTE=awarenessIDLTE, BRid=BRid, NbeaconsT=NbeaconsT, duplexCV2X="HD");
+expected = 1;
+verifyEqual(testCase, actual, expected);
+end
+
+function testCaseFDSameBRTSameBRF(testCase)
+% in FD mode, tx and ix must be sharing the same BRT and BRF
+% let 1 be tx, 2 be rx, 3 be interferer
+% let the BRid in contention be 9
+errorRxList = [1 2 9 100 0];
+% 1 can see 2, cannot see 3
+% 2 can see 1 and 3
+% 3 can only see 2
+awarenessIDLTE = [
+    2 0 0;
+    1 3 0;
+    2 0 0;
+    ];
+% 1 and 3 share the same BRT and same BRF, don't care about 2
+BRid = [9 -1 9];
+NbeaconsT = 3;
+actual = countHiddenNodeEvents(errorRxList=errorRxList, awarenessIDLTE=awarenessIDLTE, BRid=BRid, NbeaconsT=NbeaconsT, duplexCV2X="HD");
+expected = 1;
+verifyEqual(testCase, actual, expected);
+end

--- a/WiLabV2Xsim.m
+++ b/WiLabV2Xsim.m
@@ -229,6 +229,10 @@ if outParams.printHiddenNodeProb
     %outputValues.hiddenNodeProbEvents = zeros(floor(phyParams.RawMax)+1,1);
 end
 
+if outParams.printHiddenNodeEvents
+    outputValues.hiddenNodeEvents = zeros(length(phyParams.Raw), 1);
+end
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Start Simulation
 [simValues,outputValues,appParams,simParams,phyParams,sinrManagement,outParams,stationManagement] = mainV2X(appParams,simParams,phyParams,outParams,simValues,outputValues,positionManagement);    
@@ -373,6 +377,10 @@ end
 % Print hidden node probability to file (if enabled)
 if outParams.printHiddenNodeProb
     printHiddenNodeProb(outputValues,outParams);
+end
+
+if outParams.printHiddenNodeEvents
+    printHiddenNodeEvents(outputFolder=outParams.outputFolder, simId=outParams.simID, hiddenNodeEvents=outputValues.hiddenNodeEvents);
 end
 
 % Print to XLS file


### PR DESCRIPTION
hi v2xsim maintainers,

i have more features in my fork that i created for my own research, that i would like to contribute back to upstream before i start working on the full traffic trace support.

this feature creates a new output parameter, `printHiddenNodeEvents`, that counts the number of errors that happened due to the hidden node problem. This is not the same as the existing `countHiddenNodeProb` that is no longer tested, this only looks at errors and the awareness matrix to decide. It should also be faster because I used vectorization as much as possible, the old code used lots of nested for loops.

Also, I would like to start writing automated test suites for the simulator to it is easier for future maintainers to do regression tests. In this commit I show an example of how unit tests for the simulator can be written. I am using MATLAB's built in test framework, [see tutorial here](https://www.mathworks.com/help/matlab/matlab_prog/write-simple-test-case-with-functions.html). I also use [the package/namespace feature](https://www.mathworks.com/help/matlab/matlab_oop/scoping-classes-with-packages.html) to avoid polluting the global namespace since we are going to have many many function names.

For reference, the tests in this branch can be run after adding the `Tests` folder to MATLAB path and running in the command window:

```
run(v2xsim_tests.unit.out.test_countHiddenNodeEvents)
```