### PR TITLE
attempt to support a configurable buffer size

### DIFF
--- a/MainFilesCV2X/mainCV2XttiEnds.m
+++ b/MainFilesCV2X/mainCV2XttiEnds.m
@@ -8,7 +8,7 @@ function [phyParams,simValues,outputValues,sinrManagement,stationManagement,time
 % geneated in a subframe during which the station is transmitting is
 % not correctly managed
 for idLte = stationManagement.activeIDsCV2X'   
-    if stationManagement.pckBuffer(idLte)>1
+    if stationManagement.pckBuffer(idLte) > appParams.bufferLength
         [stationManagement,outputValues] = bufferOverflowLTE(idLte,timeManagement,positionManagement,stationManagement,phyParams,appParams,outputValues,outParams);
         stationManagement.pckNextAttempt(idLte) = 1;     
     end
@@ -48,7 +48,7 @@ elseif simParams.BRAlgorithm == constants.REASSIGN_BR_RAND_ALLOCATION
         stationManagement.BRid(stationManagement.activeIDsCV2X(hasNewPacketThisTbeacon),:) = BRidModified;
     end
     
-elseif mod(timeManagement.elapsedTime_TTIs,appParams.NbeaconsT)==0
+elseif timeManagement.elapsedTime_TTIs == 1 || mod(timeManagement.elapsedTime_TTIs,appParams.NbeaconsT) == 0
     % All other algorithms except standard Mode 4
     % TODO not checked in version 5.X
     

--- a/MainFilesCV2X/mainCV2XttiStarts.m
+++ b/MainFilesCV2X/mainCV2XttiStarts.m
@@ -30,7 +30,9 @@ iTransmitting = 1;
 currentT = (mod((timeManagement.elapsedTime_TTIs-1),appParams.NbeaconsT)+1);
 idLteHasPck = stationManagement.activeIDsCV2X(stationManagement.pckBuffer(stationManagement.activeIDsCV2X) >= 1);
 for idLte = idLteHasPck'    
-    attemptToDo = stationManagement.pckNextAttempt(idLte);
+    % attemptToDo = stationManagement.pckNextAttempt(idLte);
+    % was BRid ever going to have more than one column...?
+    attemptToDo = 1;
     if ceil((stationManagement.BRid(idLte,attemptToDo))/appParams.NbeaconsF)==currentT
         stationManagement.transmittingIDsCV2X(iTransmitting) = idLte;
         stationManagement.transmittingFusedLTE(iTransmitting) = mod((stationManagement.BRid(idLte,attemptToDo))-1,appParams.NbeaconsF)+1;
@@ -71,7 +73,7 @@ end
 % This has been done to allow the possibility of allowing the possibility
 % of triggering retransmissions
 if ~isempty(stationManagement.transmittingIDsCV2X)
-    stationManagement.pckTxOccurring(stationManagement.transmittingIDsCV2X) = stationManagement.pckNextAttempt(stationManagement.transmittingIDsCV2X);
+    stationManagement.pckTxOccurring(stationManagement.transmittingIDsCV2X) = logical(stationManagement.pckNextAttempt(stationManagement.transmittingIDsCV2X));
  	stationManagement.pckNextAttempt(stationManagement.transmittingIDsCV2X) = stationManagement.pckNextAttempt(stationManagement.transmittingIDsCV2X) + 1;
     txIDlastTx = stationManagement.transmittingIDsCV2X(stationManagement.pckNextAttempt(stationManagement.transmittingIDsCV2X)>stationManagement.cv2xNumberOfReplicas(stationManagement.transmittingIDsCV2X));
     stationManagement.pckBuffer(txIDlastTx) = stationManagement.pckBuffer(txIDlastTx)-1;

--- a/MainFilesIEEE802.11p/updateVehicleEndingTx11p.m
+++ b/MainFilesIEEE802.11p/updateVehicleEndingTx11p.m
@@ -42,7 +42,7 @@ else
         % in idle state
         stationManagement.vehicleState(idEvent) = constants.V_STATE_11P_IDLE; % idle
         timeManagement.timeNextTxRx11p(idEvent) = Inf;
-    elseif stationManagement.pckBuffer(idEvent) >= 1
+    elseif stationManagement.pckBuffer(idEvent) >= appParams.bufferLength
         % If there are other packets in the queue, a new
         % backoff is initialized and started
         % in this case is retransmission, because the queue only has one

--- a/MatFilesInit/initiateApplicationParameters.m
+++ b/MatFilesInit/initiateApplicationParameters.m
@@ -153,7 +153,13 @@ end
 % if simParams.mco_nVehInterf<0
 %     error('Error: "simParams.mco_nVehInterf" cannot be < 0');
 % end
-    
+
+% [bufferLength]
+[appParams,varargin]= addNewParam(appParams,'bufferLength',1,'Length of the vehicle packet buffer','integer',fileCfg,varargin{1});
+if appParams.bufferLength<1
+    error('bufferLength must be >= 1');
+end
+
 fprintf('\n');
 %
 %%%%%%%%%


### PR DESCRIPTION
Hi v2xsim maintainers,

This is an attempt to support a configurable buffer size to reduce the chance of buffer overflow - please review to see if it is technically sound. I think the `printDataAge` needs to be updated too, but I will wait for your review.

The reason why I wanted to support a configurable buffer size was because I noticed very peculiar behavior when comparing NR-V2X Mode 1 and Mode 2 algorithms. In low density scenarios, where there are obviously more BRs than vehicles, even with never blocking scenarios such as the MRD algorithm, the blocking rate sometimes is not 0. This did not make sense to me, and using the debugger, I found that it was due to buffer overflow.

All Mode 1 (centralized) algorithms will suffer from this sliding-window buffer overflow problem. This is an example of how it happens:

- A vehicle generates a packet at every 100ms intervals, with an added random variable. So packet generation for three epochs can look like `0.04s 0.15s 0.29s`
- In the first epoch, the BR algorithm might assign a BRT that happens before the packet generation event. So in the first epoch, no transmission happens.
- At `0.04s`, a packet is generated and the buffer is filled.
- In the second epoch (`0.10s`), the BR algorithm happens to assign a BRT that is now __after__ the next packet generation event, say at the 80th BRT (`0.18s`)
- At `0.15s`, another packet is generated, causing buffer overflow.

This happens often enough that it causes a significant hit in the PRR. Even just changing the buffer size to 2, I reduced the number of overflow events to 0 and the PRR improves immensely. Mode 2 does not appear to suffer from this problem, because (if I understand the autonomous sensing and selection procedure correctly), the BRT assigned will always be not more than 0.1s away. In addition, the sensing and selection procedure happens every 0.01s, while the Mode 1 only runs every 0.1s. This effectively ensures that the packets don't stay in the buffer for more than 0.1s.

Because of this problem I found it difficult to make fair performance comparisons with Mode 1 and Mode 2. So I tried to implement a configurable buffer size. Surely having a buffer that is not just size 1 is a realistic capability? Anyway, in case it is not realistic, the original functionality is still not changed if you leave the new parameter `bufferLength` to the default 1. I eagerly await your input on this matter.