### PR TITLE
enhance usage of posDelay, add posPacketLoss param

### DIFF
--- a/MainFiles/mainInit.m
+++ b/MainFiles/mainInit.m
@@ -68,6 +68,7 @@ outputValues.Nvehicles = length(stationManagement.activeIDs);
 outputValues.NvehiclesTOT = outputValues.NvehiclesTOT + outputValues.Nvehicles;
 outputValues.NvehiclesLTE = outputValues.NvehiclesLTE + length(stationManagement.activeIDsCV2X);
 outputValues.Nvehicles11p = outputValues.Nvehicles11p + length(stationManagement.activeIDs11p);
+outputValues.meanPositionError = zeros(outputValues.Nvehicles, 1);
 
 %% Initialization of packets management 
 % Number of packets in the queue of each node
@@ -201,15 +202,22 @@ else
 end
 
 % Copy real coordinates into estimated coordinates at eNodeB (no positioning error)
-simValues.XvehicleEstimated = positionManagement.XvehicleReal;
-simValues.YvehicleEstimated = positionManagement.YvehicleReal;
+positionManagement.XvehicleEstimated = positionManagement.XvehicleReal;
+positionManagement.YvehicleEstimated = positionManagement.YvehicleReal;
 
 % Call function to compute distances
-% computeDistance(i,j): computeDistance from vehicle with index i to vehicle with index j
-% positionManagement.distance matrix has dimensions equal to simValues.IDvehicle x simValues.IDvehicle in order to
-% speed up the computation (only vehicles present at the considered instant)
-% positionManagement.distance(i,j): positionManagement.distance from vehicle with index i to vehicle with index j
-[positionManagement,stationManagement] = computeDistance (simParams,simValues,stationManagement,positionManagement);
+[positionManagement] = computeDistance (positionManagement);
+
+% Position Delay
+% timetables of old positions
+n_vehicles = length(positionManagement.XvehicleReal);
+positionManagement.XvehicleHistory = cell(n_vehicles, 1);
+positionManagement.YvehicleHistory = cell(n_vehicles, 1);
+for i = 1:n_vehicles
+    positionManagement.XvehicleHistory{i} = timetable(Size=[0 1], VariableTypes={'double'}, TimeStep=seconds(simParams.positionTimeResolution));
+    positionManagement.YvehicleHistory{i} = timetable(Size=[0 1], VariableTypes={'double'}, TimeStep=seconds(simParams.positionTimeResolution));
+end
+
 
 % Save positionManagement.distance matrix
 positionManagement.XvehicleRealOld = positionManagement.XvehicleReal;

--- a/MainFilesCV2X/mainCV2XttiEnds.m
+++ b/MainFilesCV2X/mainCV2XttiEnds.m
@@ -53,7 +53,7 @@ elseif mod(timeManagement.elapsedTime_TTIs,appParams.NbeaconsT)==0
     % TODO not checked in version 5.X
     
     %% Radio Resources Reassignment
-    if ismember(simParams.BRAlgorithm, constants.CONTROLLED_ALGORITHMS)
+    if ismember(simParams.BRAlgorithm, constants.REASSIGN_BR_ALGORITHMS_CONTROLLED)
         
         if timeManagement.elapsedTime_TTIs > 0
             % Current scheduled reassign period

--- a/MainFilesCV2X/mainCV2XttiEnds.m
+++ b/MainFilesCV2X/mainCV2XttiEnds.m
@@ -53,7 +53,7 @@ elseif mod(timeManagement.elapsedTime_TTIs,appParams.NbeaconsT)==0
     % TODO not checked in version 5.X
     
     %% Radio Resources Reassignment
-    if simParams.BRAlgorithm==constants.REASSIGN_BR_REUSE_DIS_SCHEDULED_VEH || simParams.BRAlgorithm==constants.REASSIGN_BR_MAX_REUSE_DIS || simParams.BRAlgorithm==constants.REASSIGN_BR_MIN_REUSE_POW
+    if ismember(simParams.BRAlgorithm, constants.CONTROLLED_ALGORITHMS)
         
         if timeManagement.elapsedTime_TTIs > 0
             % Current scheduled reassign period
@@ -79,7 +79,7 @@ elseif mod(timeManagement.elapsedTime_TTIs,appParams.NbeaconsT)==0
 
         % BRs reassignment (CONTROLLED with MAXIMUM REUSE DISTANCE)
         %[stationManagement.BRid,Nreassign] = BRreassignmentControlledMaxReuse(stationManagement.activeIDsCV2X,stationManagement.BRid,scheduledID,stationManagement.neighborsIDLTE,appParams.NbeaconsT,appParams.NbeaconsF);
-        [stationManagement.BRid,Nreassign] = BRreassignmentControlledMaxReuse(stationManagement.activeIDsCV2X,stationManagement.BRid,scheduledID,stationManagement.allNeighborsID,appParams.NbeaconsT,appParams.NbeaconsF);
+        [stationManagement.BRid,Nreassign] = BRreassignmentControlledMaxReuse(stationManagement.activeIDsCV2X,stationManagement.BRid,scheduledID,stationManagement.allNeighborsIDEstimated,appParams.NbeaconsT,appParams.NbeaconsF);
 
     elseif simParams.BRAlgorithm == constants.REASSIGN_BR_MIN_REUSE_POW
 
@@ -113,7 +113,7 @@ elseif mod(timeManagement.elapsedTime_TTIs,appParams.NbeaconsT)==0
     elseif simParams.BRAlgorithm==constants.REASSIGN_BR_ORDERED_ALLOCATION
 
         % Call Benchmark Algorithm 102 (ORDERED ALLOCATION)
-        [stationManagement.BRid,Nreassign] = BRreassignmentOrdered(positionManagement.XvehicleReal,stationManagement.activeIDsCV2X,stationManagement.BRid,appParams.NbeaconsT,appParams.NbeaconsF);
+        [stationManagement.BRid,Nreassign] = BRreassignmentOrdered(positionManagement.XvehicleEstimated,stationManagement.activeIDsCV2X,stationManagement.BRid,appParams.NbeaconsT,appParams.NbeaconsF);
 
     end
 

--- a/MatFilesInit/constants.m
+++ b/MatFilesInit/constants.m
@@ -151,9 +151,14 @@ classdef constants
 
     % ORDERED ALLOCATION (following X coordinate)
     REASSIGN_BR_ORDERED_ALLOCATION = 102;
-    % ***** this two Algorithms used as benchmarks *****
-    
 
+    REASSIGN_BR_ALGORITHMS_CONTROLLED = [constants.REASSIGN_BR_REUSE_DIS_SCHEDULED_VEH
+                            constants.REASSIGN_BR_MAX_REUSE_DIS
+                            constants.REASSIGN_BR_POW_CONTROL
+                            constants.REASSIGN_BR_MIN_REUSE_POW
+                            constants.REASSIGN_BR_ORDERED_ALLOCATION];
+    REASSIGN_BR_ALOGRITHMS_AUTONOMOUS = [constants.REASSIGN_BR_STD_MODE_4 
+                            constants.REASSIGN_BR_RAND_ALLOCATION];
     %% ****************************************
 	%% CHANNEL MODEL
 

--- a/MatFilesInit/constants.m
+++ b/MatFilesInit/constants.m
@@ -157,7 +157,7 @@ classdef constants
                             constants.REASSIGN_BR_POW_CONTROL
                             constants.REASSIGN_BR_MIN_REUSE_POW
                             constants.REASSIGN_BR_ORDERED_ALLOCATION];
-    REASSIGN_BR_ALOGRITHMS_AUTONOMOUS = [constants.REASSIGN_BR_STD_MODE_4 
+    REASSIGN_BR_ALGORITHMS_AUTONOMOUS = [constants.REASSIGN_BR_STD_MODE_4 
                             constants.REASSIGN_BR_RAND_ALLOCATION];
     %% ****************************************
 	%% CHANNEL MODEL

--- a/MatFilesInit/initiateBRAssignmentAlgorithm.m
+++ b/MatFilesInit/initiateBRAssignmentAlgorithm.m
@@ -50,7 +50,7 @@ function [simParams, phyParams, varargin] = initiateBRAssignmentAlgorithm(simPar
 
         % [posPacketLoss]
         [simParams, varargin] = addNewParam(simParams, 'posPacketLoss', 0, 'V2NB Positioning Signal Packet Loss Probability (only controlled BR algorithms)', 'double', fileCfg, varargin{1});
-        if simParams.posPacketLoss <= 0 || simParams.posPacketLoss < 1
+        if simParams.posPacketLoss < 0 || simParams.posPacketLoss > 1
             error('Error: "simParams.posPacketLoss must be 0 <= p < 1');
         end
 

--- a/MatFilesInit/initiateBRAssignmentAlgorithm.m
+++ b/MatFilesInit/initiateBRAssignmentAlgorithm.m
@@ -1,324 +1,276 @@
-function [simParams,phyParams,varargin] = initiateBRAssignmentAlgorithm(simParams,phyParams,Tbeacon,fileCfg,varargin)
-% function [simParams,varargin]= initiateBRAssignmentAlgorithm(simParams,fileCfg,varargin)
-%
-% Main settings of the simulation
-% It takes in input the structure simParams, the name of the (possible) file config and the inputs
-% of the main function
-% It returns the structure "simParams"
+function [simParams, phyParams, varargin] = initiateBRAssignmentAlgorithm(simParams, phyParams, Tbeacon, fileCfg, varargin)
+    % function [simParams,varargin]= initiateBRAssignmentAlgorithm(simParams,fileCfg,varargin)
+    %
+    % Main settings of the simulation
+    % It takes in input the structure simParams, the name of the (possible) file config and the inputs
+    % of the main function
+    % It returns the structure "simParams"
 
-fprintf('Settings of resource assignement algorithm\n');
+    fprintf('Settings of resource assignement algorithm\n');
 
-% [BRAlgorithm]
-% Selects the BR reassignment algorithm:
-% Check .../MatFilesInit/constants.m for details
-% 2 -> CONTROLLED with REUSE DISTANCE and scheduled vehicles
-% 7 -> CONTROLLED with MAXIMUM REUSE DISTANCE (MRD)
-% 8 -> AUTONOMOUS with SENSING (3GPP STANDARD MODE 4) - ON A BEACON PERIOD BASIS
-% 18 -> AUTONOMOUS with SENSING (3GPP STANDARD LTE-MODE-4 or NR-MODE-2) - ON A SLOT BASIS
-%
-% 9 -> CONTROLLED with POWER CONTROL
-% 10 -> CONTROLLED with MINIMUM REUSE POWER (MRP)
+    % [BRAlgorithm]
+    % Selects the BR reassignment algorithm:
+    % Check .../MatFilesInit/constants.m for details
+    % 2 -> CONTROLLED with REUSE DISTANCE and scheduled vehicles
+    % 7 -> CONTROLLED with MAXIMUM REUSE DISTANCE (MRD)
+    % 8 -> AUTONOMOUS with SENSING (3GPP STANDARD MODE 4) - ON A BEACON PERIOD BASIS
+    % 18 -> AUTONOMOUS with SENSING (3GPP STANDARD LTE-MODE-4 or NR-MODE-2) - ON A SLOT BASIS
+    %
+    % 9 -> CONTROLLED with POWER CONTROL
+    % 10 -> CONTROLLED with MINIMUM REUSE POWER (MRP)
 
-% [BENCHMARKS Algorithms]
-% Algorithms used as benchmarks
-% 101 -> RANDOM ALLOCATION
-% 102 -> ORDERED ALLOCATION (following X coordinate)
+    % [BENCHMARKS Algorithms]
+    % Algorithms used as benchmarks
+    % 101 -> RANDOM ALLOCATION
+    % 102 -> ORDERED ALLOCATION (following X coordinate)
 
-[simParams,varargin] = addNewParam(simParams,'BRAlgorithm',constants.REASSIGN_BR_STD_MODE_4,'Assignment algorithm','integer',fileCfg,varargin{1});
-switch simParams.BRAlgorithm
-    case constants.REASSIGN_BR_REUSE_DIS_SCHEDULED_VEH  % CONTROLLED with REUSE DISTANCE and scheduled vehicles
+    implementedAlgorithms = [constants.REASSIGN_BR_ALGORITHMS_CONTROLLED ; constants.REASSIGN_BR_ALOGRITHMS_AUTONOMOUS];
+
+    [simParams, varargin] = addNewParam(simParams, 'BRAlgorithm', constants.REASSIGN_BR_STD_MODE_4, 'Assignment algorithm', 'integer', fileCfg, varargin{1});
+    if ~ismember(simParams.BRAlgorithm, implementedAlgorithms)
+        error('Error: "simParams.BRAlgorithm" not valid. Algorithm not implemented.');
+    end
+
+    % Add parameters common to all controlled algorithms
+    if ismember(simParams.BRAlgorithm, constants.REASSIGN_BR_ALGORITHMS_CONTROLLED)
+        % [posDelay]
+        % LTE position delay
+        [simParams, varargin] = addNewParam(simParams, 'posDelay', 0, 'V2NB Positioning Delay (only controlled BR algorithms) (s)', 'double', fileCfg, varargin{1});
+        if simParams.posDelay < 0
+            error('Error: "simParams.posDelay" cannot be negative');
+        end
+
         % [posError95]
         % LTE Positioning Accuracy (Gaussian model): 95th percentile of the error (m)
-        [simParams,varargin] = addNewParam(simParams,'posError95',0,'LTE positioning error - 95th percentile (only controlled) (m)','double',fileCfg,varargin{1});
-        simParams.sigmaPosError = simParams.posError95/1.96;   % Standard deviation of the error (m)
-    
+        [simParams, varargin] = addNewParam(simParams, 'posError95', 0, 'V2NB Positioning error - 95th percentile (only controlled BR algorithms) (m)', 'double', fileCfg, varargin{1});
+        if simParams.posError95 < 0
+            error('Error: "simParams.posError95" cannot be negative');
+        end
+        simParams.sigmaPosError = simParams.posError95 / 1.96;   % Standard deviation of the error (m)
+
+        % [posPacketLoss]
+        [simParams, varargin] = addNewParam(simParams, 'posPacketLoss', 0, 'V2NB Positioning Signal Packet Loss Probability (only controlled BR algorithms)', 'double', fileCfg, varargin{1});
+        if simParams.posPacketLoss <= 0 || simParams.posPacketLoss < 1
+            error('Error: "simParams.posPacketLoss must be 0 <= p < 1');
+        end
+
         % [Tupdate]
         % Time interval between each position update at the eNodeBs (s)
-        [simParams,varargin]= addNewParam(simParams,'Tupdate',Tbeacon,'Time interval between position updates at the eNodeBs (s)','double',fileCfg,varargin{1});
-        if simParams.Tupdate<=0
+        [simParams, varargin] = addNewParam(simParams, 'Tupdate', Tbeacon, 'Time interval between position updates at the eNodeBs (s)', 'double', fileCfg, varargin{1});
+        if simParams.Tupdate <= 0
             error('Error: "simParams.Tupdate" cannot <= 0');
         end
-    
-        % [Mreuse]
-        % Reuse margin (m) (only valid for controlled LTE-V2V with reuse distance [BRAlgorithm 2])
-        [simParams,varargin]= addNewParam(simParams,'Mreuse',0,'Reuse margin (m)','integer',fileCfg,varargin{1});
-        
-        % [Treassign]
-        % Time interval between each scheduled BR reassignment (BRAlgorithm 2,7,9,10) (s)
-        % By default it is set equal to the beacon period
-        [simParams,varargin]= addNewParam(simParams,'Treassign',Tbeacon,'Interval of scheduled reassignment (BRAlgorithm 2,7,9,10) (s)','double',fileCfg,varargin{1});
-        if simParams.Treassign<=0
-            error('Error: "simParams.Treassign" cannot be <= 0.');
-        end
-    case constants.REASSIGN_BR_MAX_REUSE_DIS  % CONTROLLED with MAXIMUM REUSE DISTANCE (MRD)
-        simParams.posError95 = 0;
-        simParams.sigmaPosError = 0;
-        simParams.Tupdate = Tbeacon;
-        simParams.Mreuse=0;
 
         % [Treassign]
-        % Time interval between each scheduled BR reassignment (BRAlgorithm 2,7,9,10) (s)
+        % Time interval between each scheduled BR reassignment (Controlled BR algorithms) (s)
         % By default it is set equal to the beacon period
-        [simParams,varargin]= addNewParam(simParams,'Treassign',Tbeacon,'Interval of scheduled reassignment (BRAlgorithm 2,7,9,10) (s)','double',fileCfg,varargin{1});
-        if simParams.Treassign<=0
+        [simParams, varargin] = addNewParam(simParams, 'Treassign', Tbeacon, 'Interval of scheduled reassignment (Controlled BR algorithms) (s)', 'double', fileCfg, varargin{1});
+        if simParams.Treassign <= 0
             error('Error: "simParams.Treassign" cannot be <= 0.');
         end
-    case constants.REASSIGN_BR_POW_CONTROL  % CONTROLLED with POWER CONTROL
+    else
+        simParams.posDelay = 0;
         simParams.posError95 = 0;
+        simParams.posPacketLoss = 0;
         simParams.sigmaPosError = 0;
         simParams.Tupdate = Tbeacon;
-        simParams.Mreuse=0;
-
-        % [Treassign]
-        % Time interval between each scheduled BR reassignment (BRAlgorithm 2,7,9,10) (s)
-        % By default it is set equal to the beacon period
-        [simParams,varargin]= addNewParam(simParams,'Treassign',Tbeacon,'Interval of scheduled reassignment (BRAlgorithm 2,7,9,10) (s)','double',fileCfg,varargin{1});
-        if simParams.Treassign<=0
-            error('Error: "simParams.Treassign" cannot be <= 0.');
-        end
-    case constants.REASSIGN_BR_MIN_REUSE_POW  % CONTROLLED with MINIMUM REUSE POWER (MRP)
-        simParams.posError95 = 0;
-        simParams.sigmaPosError = 0;
-        simParams.Tupdate = Tbeacon;
-        simParams.Mreuse=0;
-
-        % [Treassign]
-        % Time interval between each scheduled BR reassignment (BRAlgorithm 2,7,9,10) (s)
-        % By default it is set equal to the beacon period
-        [simParams,varargin]= addNewParam(simParams,'Treassign',Tbeacon,'Interval of scheduled reassignment (BRAlgorithm 2,7,9,10) (s)','double',fileCfg,varargin{1});
-        if simParams.Treassign<=0
-            error('Error: "simParams.Treassign" cannot be <= 0.');
-        end
-
-        % [knownShadowing]
-        % Selects if shadowing is estimated at the eNB side
-        [simParams,varargin]= addNewParam(simParams,'knownShadowing',false,'if shadowing is estimated at the eNB side','bool',fileCfg,varargin{1});
-
-    case constants.REASSIGN_BR_STD_MODE_4  % AUTONOMOUS with SENSING (3GPP STANDARD MODE 4) - ON A SUBFRAME BASIS
-        simParams.posError95 = 0;
-        simParams.sigmaPosError = 0;
-        simParams.Tupdate = Tbeacon;
-        simParams.Mreuse=0;
-
-        % [resourceReEvaluation]
-        % Enables the the resource re-evaluation in 5G
-        [simParams,varargin]= addNewParam(simParams,'resourceReEvaluation',false,'Activates the resource re-evaluation in NR-V2X','bool',fileCfg,varargin{1});
-        if simParams.resourceReEvaluation == true && simParams.mode5G ~=1
-            error('Error: "simParams.mode5G" must be equal to: 5G-V2X when resource re-evaluation is active');
-        end
-
-        % [reEvalAfterEmptyResource]
-        % Enables the the resource re-evaluation after a user has not transmitted in a previously reserved resource
-        [simParams,varargin]= addNewParam(simParams,'reEvalAfterEmptyResource',false,'Activates the resource re-evaluation in NR-V2X after empty transmission','bool',fileCfg,varargin{1});
-        if simParams.reEvalAfterEmptyResource == true && simParams.mode5G ~=1
-            error('Error: "simParams.mode5G" must be equal to: 5G-V2X when resource re-evaluation is active');
-        end
-        if simParams.reEvalAfterEmptyResource == true && simParams.resourceReEvaluation == false
-            error('Error: "simParams.reEvalAfterEmptyResource" cannot be true when resourceReEvaluation is false');
-        end
-
-        % [dynamicScheduling]
-        % Enables the dynamic scheduling: resources are changed at each generation
-        [simParams,varargin]= addNewParam(simParams,'dynamicScheduling',false,'Probability to keep the previously selected BR','bool',fileCfg,varargin{1});
-
-        % [probResKeep]
-        % Probability to keep the previously selected BR
-        [simParams,varargin]= addNewParam(simParams,'probResKeep',0.8*(~simParams.dynamicScheduling),'Probability to keep the previously selected BR','double',fileCfg,varargin{1});
-        if simParams.probResKeep<0 || simParams.probResKeep>1
-            error('Error: "simParams.probResKeep" must be within 0 and 0.8. In this version it can take also values bigger than 0.8');
-        elseif simParams.probResKeep>0.8 && simParams.probResKeep<=1
-            warning('Warning: "simParams.probResKeep" must be within 0 and 0.8 according to specifications. A value bigger than 0.8 has been inserted');
-        end
-        if simParams.dynamicScheduling == true && simParams.probResKeep~=0
-            error('Error: "simParams.probResKeep" must be 0 when Dynamic Scheduling is selected');
-        end
-
-        % [ratioSelectedAutonomousMode]
-        % Percentage of resources to be considered for random selection
-        [simParams,varargin]= addNewParam(simParams,'ratioSelectedAutonomousMode',0.2,'Percentage of resources to be considered for random selection','double',fileCfg,varargin{1});
-        if simParams.ratioSelectedAutonomousMode<0.2 || simParams.ratioSelectedAutonomousMode>1
-            error('Error: "simParams.ratioSelectedAutonomousMode" must be more than 0.2 and not more than 1 (specs: 0.2)');
-        end
-
-        % [L2active]
-        % Parameter that gives the possibility to reintroduce L2 in mode2
-        % By default (and specifications) is active in LTE and disabled in 5G
-        [simParams,varargin]= addNewParam(simParams,'L2active',(~simParams.mode5G),'Activate or De-activate L2 in mode2/mode4','bool',fileCfg,varargin{1});
-
-        % [averageSensingActive]
-        % Parameter that gives the possibility to reintroduce the average sensing in mode2
-        % By default (and specifications) is active in LTE and disabled in 5G
-        [simParams,varargin] = addNewParam(simParams,'averageSensingActive',(~simParams.mode5G),'Activate or De-activate the average sensing mode2/mode4','bool',fileCfg,varargin{1});
-
-
-        % This can be used with same effect as averageSensingActive to unify the two conditions
-    %     % [NsensingPeriod]
-    %     % Number of beacon periods during which performing sensing
-    %     [simParams,varargin{1}{1}]= addNewParam(simParams,'NsensingPeriod',10,'Number of beacon periods during which performing sensing','integer',fileCfg,varargin{1}{1});
-    %     if simParams.NsensingPeriod<=0
-    %         error('Error: "simParams.NsensingPeriod" must be larger than 0');
-    %     end
-
-        % [TsensingPeriod]
-        % Duration of the sensing period, in seconds
-        [simParams,varargin]= addNewParam(simParams,'TsensingPeriod',1,'Duration of the sensing period, in seconds','double',fileCfg,varargin{1});
-        if simParams.TsensingPeriod<=0
-            error('Error: "simParams.TsensingPeriod" must be larger than 0');
-        end
-
-        % [minRandValueMode4]
-        % Minimum duration keeping the same allocation
-        [simParams,varargin]= addNewParam(simParams,'minRandValueMode4',-1,'Minimum duration keeping the same allocation','integer',fileCfg,varargin{1});
-        if simParams.minRandValueMode4~=-1 && simParams.minRandValueMode4<=0
-            error('Error: "simParams.minRandValueMode4" must be more than 0');
-        end
-
-        % [maxRandValueMode4]
-        % Maximum duration keeping the same allocation
-        [simParams,varargin]= addNewParam(simParams,'maxRandValueMode4',-1,'Maximum duration keeping the same allocation','integer',fileCfg,varargin{1});
-        if simParams.maxRandValueMode4~=-1 && simParams.maxRandValueMode4<=simParams.minRandValueMode4
-            error('Error: "simParams.maxRandValueMode4" must be larger than "simParams.minRandValueMode4"');
-        end
-        
-        % [powerThresholdAutonomous]
-        % Minimum power threshold to consider a BR as occupied in dBm
-        [simParams,varargin]= addNewParam(simParams,'powerThresholdAutonomous',-110,'Minimum power threshold to consider a BR as occupied in Mode 4, in dBm','double',fileCfg,varargin{1});
-        if simParams.powerThresholdAutonomous/2<-64 || simParams.powerThresholdAutonomous/2>-1 || mod(simParams.powerThresholdAutonomous,2)~=0
-            error('Error: "simParams.powerThresholdAutonomous" must be between -128 and -2, step 2 dB');
-        end
-        % From dBm to linear
-        simParams.powerThresholdAutonomous = db2pow(simParams.powerThresholdAutonomous-30);
-
-        % [minSCIsinr]
-        % Minimum SINR for a SCI to be correctly decoded
-        [phyParams,varargin] = addNewParam(phyParams,'minSCIsinr',0,'Minimum SINR for a SCI to be correctly decoded, in dB','double',fileCfg,varargin{1});
-        phyParams.minSCIsinr = db2pow(phyParams.minSCIsinr);
-        
-        % [asynMode]
-        % Enables Asynchronous transmitters
-        [simParams,varargin]= addNewParam(simParams,'asynMode',0,'Enables/Desable Asynchronous transmitters','integer',fileCfg,varargin{1});
-        if (simParams.asynMode ~=0 && simParams.asynMode ~= 1)
-            error('Error: "simParams.asynMode" cannot different from 0 or 1');
-        end
-        
-        % [percAsynUser]
-        % TODO
-        % if Asynchronous transmitters is active -> sets the percentage of
-        % Asynchronous users
-        if simParams.asynMode == 1
-            [simParams,varargin]= addNewParam(simParams,'percAsynUser',0.2,'Percentage of asynchronous users','double',fileCfg,varargin{1});
-            if simParams.percAsynUser<0 || simParams.percAsynUser>1
-                error('Error: "simParams.percAsynUser" must be within 0 and 1');
-            end
-        end
-
-        % [FDalgorithm]
-        % Enables different FD algorithm
-        [simParams,varargin]= addNewParam(simParams,'FDalgorithm',0,'Enables FD algorithm','integer',fileCfg,varargin{1});
-        if simParams.FDalgorithm~=0 && phyParams.PDelta==Inf
-            error('Error: "phyParams.PDelta" must be defined');
-        end
-        if simParams.FDalgorithm~=0 && phyParams.duplexCV2X~="FD"
-            error('Error: "phyParams.duplexCV2X" must be "FD"');
-        end
-        if ismember(simParams.FDalgorithm,[1,2]) && phyParams.cv2xNumberOfReplicasMax==2
-            error('Error: "phyParams.cv2xNumberOfReplicasMax" must be equal to 1');
-        end
-        if ismember(simParams.FDalgorithm,[3,4,5,6,7,8]) && phyParams.cv2xNumberOfReplicasMax~=2
-            error('Error: "phyParams.cv2xNumberOfReplicasMax" must be equal to 2');
-        end
-        if simParams.FDalgorithm~=0 && simParams.mode5G ~=1
-            error('Error: "simParams.mode5G" must be equal to: 5G-V2X');
-        end
-
-        % [dynamicPDelta]
-        % Enables dynamic setting of PDelta 
-        [simParams,varargin]= addNewParam(simParams,'dynamicPDelta',0,'Enables dynamic setting of PDelta','integer',fileCfg,varargin{1});
-        if (simParams.dynamicPDelta==1 && phyParams.duplexCV2X~="FD") || (simParams.dynamicPDelta==1 && simParams.FDalgorithm==0)
-            error('Error: "phyParams.duplexCV2X" must be "FD" or incompatible settings');
-        end
-
-        % [T1autonomousMode]
-        % Minimum time for the next allocation in ms
-        % For 5G, T1 is modelled as the sum of Tproc,0 and Tproc,1
-        % Tproc,1 must be smaller to 3, 2.5, or 2.25 ms for a SCS of 15, 30, 60 kHz, respectively.
-        % Tproc,0 is equivalent to 1 ms for a SCS of 15 kHz and 0.50 ms for the rest of SCS configurations. 
-        
-        if phyParams.muNumerology==0    % 4G and 5G SCS=15
-        [simParams,varargin]= addNewParam(simParams,'T1autonomousMode',1,'Minimum time for the next allocation in Autonomous Mode','integer',fileCfg,varargin{1});
-            if simParams.T1autonomousMode<1 || simParams.T1autonomousMode>4
-                error('Error: "simParams.T1autonomousMode" must be between 1 and 4 in LTE and 5G SCS=15');
-            end
-        elseif phyParams.muNumerology==1 || phyParams.muNumerology==2 % 5G SCS=30 and 5G SCS=60
-            [simParams,varargin]= addNewParam(simParams,'T1autonomousMode',0.5,'Minimum time for the next allocation in Autonomous Mode','double',fileCfg,varargin{1});
-            if (simParams.T1autonomousMode<0.5 || simParams.T1autonomousMode>3)&&(phyParams.muNumerology==1)
-                error('Error: "simParams.T1autonomousMode" must be between 0.5 and 3 in 5G with SCS=30');
-            elseif (simParams.T1autonomousMode<0.5 || simParams.T1autonomousMode>2.75)&&(phyParams.muNumerology==2)
-                error('Error: "simParams.T1autonomousMode" must be between 0.5 and 2.75 in 5G with SCS=60');
-            end
-        end
-                
-        % [T2autonomousMode]
-        % Maximum time for the next allocation in ms
-        [simParams,varargin]= addNewParam(simParams,'T2autonomousMode',100,'Maximum time for the next allocation in autonomous mode','integer',fileCfg,varargin{1});
-            if simParams.T2autonomousMode<20 || simParams.T2autonomousMode>100
-                error('Error: "simParams.T2autonomousMode" must be between 20 and 100 ms in LTE and 5G');
-            end
-        
-        simParams.T1autonomousModeTTIs = simParams.T1autonomousMode*(2^phyParams.muNumerology);    % T1 in terms of TTIs
-        simParams.T2autonomousModeTTIs = simParams.T2autonomousMode*(2^phyParams.muNumerology);    % T2 in terms of TTIs
-    case constants.REASSIGN_BR_RAND_ALLOCATION  % RANDOM ALLOCATION
-        simParams.posError95 = 0;
-        simParams.sigmaPosError = 0;
-        simParams.Tupdate = Tbeacon;
-        simParams.Mreuse=0;
-
-        % [T1autonomousMode]
-        % Minimum time for the next allocation in ms
-        % For 5G, T1 is modelled as the sum of Tproc,0 and Tproc,1
-        % Tproc,1 must be smaller to 3, 2.5, or 2.25 ms for a SCS of 15, 30, 60 kHz, respectively.
-        % Tproc,0 is equivalent to 1 ms for a SCS of 15 kHz and 0.50 ms for the rest of SCS configurations. 
-        if hyParams.muNumerologyp == 0    % 4G and 5G SCS=15
-            [simParams,varargin]= addNewParam(simParams,'T1autonomousMode',1,'Minimum time for the next allocation in Autonomous Mode','integer',fileCfg,varargin{1});
-            if simParams.T1autonomousMode < 1 || simParams.T1autonomousMode > 4
-                error('Error: "simParams.T1autonomousMode" must be between 1 and 4 in LTE and 5G SCS=15');
-            end
-        elseif phyParams.muNumerology == 1 || phyParams.muNumerology == 2 % 5G SCS=30 and 5G SCS=60
-            [simParams,varargin]= addNewParam(simParams,'T1autonomousMode',0.5,'Minimum time for the next allocation in Autonomous Mode','double',fileCfg,varargin{1});
-            if (simParams.T1autonomousMode < 0.5 || simParams.T1autonomousMode > 3)&&(phyParams.muNumerology == 1)
-                error('Error: "simParams.T1autonomousMode" must be between 0.5 and 3 in 5G with SCS=30');
-            elseif (simParams.T1autonomousMode < 0.5 || simParams.T1autonomousMode > 2.75)&&(phyParams.muNumerology == 2)
-                error('Error: "simParams.T1autonomousMode" must be between 0.5 and 2.75 in 5G with SCS=60');
-            end
-        end
-                    
-        % [T2autonomousMode]
-        % Maximum time for the next allocation in ms
-        [simParams,varargin]= addNewParam(simParams,'T2autonomousMode',100,'Maximum time for the next allocation in autonomous mode','integer',fileCfg,varargin{1});
-            if simParams.T2autonomousMode<20 || simParams.T2autonomousMode>100
-                error('Error: "simParams.T2autonomousMode" must be between 20 and 100 ms in LTE and 5G');
-            end
-        simParams.T1autonomousModeTTIs = simParams.T1autonomousMode*(2^phyParams.muNumerology);    % T1 in terms of TTIs
-        simParams.T2autonomousModeTTIs = simParams.T2autonomousMode*(2^phyParams.muNumerology);    % T2 in terms of TTIs
-    case constants.REASSIGN_BR_ORDERED_ALLOCATION  % ORDERED ALLOCATION (following X coordinate)
-        simParams.posError95 = 0;
-        simParams.sigmaPosError = 0;
-        simParams.Tupdate = Tbeacon;
-        simParams.Mreuse=0;
-    otherwise
-        error('Error: "simParams.BRAlgorithm" not valid. Algorithm not implemented.');
-end
-
-if ~ismember(simParams.BRAlgorithm, [constants.REASSIGN_BR_STD_MODE_4, constants.REASSIGN_BR_RAND_ALLOCATION])
-    if phyParams.BRoverlapAllowed
-        error('Partial overlap in the frequency domain implemented only for Mode 4 (alg. 18) or Random (101)');
+        simParams.Mreuse = 0;
     end
 
-    if phyParams.cv2xNumberOfReplicasMax > 1 
-        error('HHARQ implemented only for Mode 4 (alg. 18 and alg. 101)');
-    end
-end
+    % Initalize BRAlgorithm-specific parameters
+    switch simParams.BRAlgorithm
+        case constants.REASSIGN_BR_REUSE_DIS_SCHEDULED_VEH  % CONTROLLED with REUSE DISTANCE and scheduled vehicles
+            % [Mreuse]
+            % Reuse margin (m) (only valid for controlled LTE-V2V with reuse distance [BRAlgorithm 2])
+            [simParams, varargin] = addNewParam(simParams, 'Mreuse', 0, 'Reuse margin (m)', 'integer', fileCfg, varargin{1});
+        case constants.REASSIGN_BR_MIN_REUSE_POW  % CONTROLLED with MINIMUM REUSE POWER (MRP)
+            % [knownShadowing]
+            % Selects if shadowing is estimated at the eNB side
+            [simParams, varargin] = addNewParam(simParams, 'knownShadowing', false, 'if shadowing is estimated at the eNB side', 'bool', fileCfg, varargin{1});
+        case constants.REASSIGN_BR_STD_MODE_4  % AUTONOMOUS with SENSING (3GPP STANDARD MODE 4) - ON A SUBFRAME BASIS
+            simParams.posError95 = 0;
+            simParams.sigmaPosError = 0;
+            simParams.Tupdate = Tbeacon;
+            simParams.Mreuse = 0;
 
-fprintf('\n');
+            % [resourceReEvaluation]
+            % Enables the the resource re-evaluation in 5G
+            [simParams, varargin] = addNewParam(simParams, 'resourceReEvaluation', false, 'Activates the resource re-evaluation in NR-V2X', 'bool', fileCfg, varargin{1});
+            if simParams.resourceReEvaluation == true && simParams.mode5G ~= 1
+                error('Error: "simParams.mode5G" must be equal to: 5G-V2X when resource re-evaluation is active');
+            end
+
+            % [reEvalAfterEmptyResource]
+            % Enables the the resource re-evaluation after a user has not transmitted in a previously reserved resource
+            [simParams, varargin] = addNewParam(simParams, 'reEvalAfterEmptyResource', false, 'Activates the resource re-evaluation in NR-V2X after empty transmission', 'bool', fileCfg, varargin{1});
+            if simParams.reEvalAfterEmptyResource == true && simParams.mode5G ~= 1
+                error('Error: "simParams.mode5G" must be equal to: 5G-V2X when resource re-evaluation is active');
+            end
+            if simParams.reEvalAfterEmptyResource == true && simParams.resourceReEvaluation == false
+                error('Error: "simParams.reEvalAfterEmptyResource" cannot be true when resourceReEvaluation is false');
+            end
+
+            % [dynamicScheduling]
+            % Enables the dynamic scheduling: resources are changed at each generation
+            [simParams, varargin] = addNewParam(simParams, 'dynamicScheduling', false, 'Probability to keep the previously selected BR', 'bool', fileCfg, varargin{1});
+
+            % [probResKeep]
+            % Probability to keep the previously selected BR
+            [simParams, varargin] = addNewParam(simParams, 'probResKeep', 0.8 * (~simParams.dynamicScheduling), 'Probability to keep the previously selected BR', 'double', fileCfg, varargin{1});
+            if simParams.probResKeep < 0 || simParams.probResKeep > 1
+                error('Error: "simParams.probResKeep" must be within 0 and 0.8. In this version it can take also values bigger than 0.8');
+            elseif simParams.probResKeep > 0.8 && simParams.probResKeep <= 1
+                warning('Warning: "simParams.probResKeep" must be within 0 and 0.8 according to specifications. A value bigger than 0.8 has been inserted');
+            end
+            if simParams.dynamicScheduling == true && simParams.probResKeep ~= 0
+                error('Error: "simParams.probResKeep" must be 0 when Dynamic Scheduling is selected');
+            end
+
+            % [ratioSelectedAutonomousMode]
+            % Percentage of resources to be considered for random selection
+            [simParams, varargin] = addNewParam(simParams, 'ratioSelectedAutonomousMode', 0.2, 'Percentage of resources to be considered for random selection', 'double', fileCfg, varargin{1});
+            if simParams.ratioSelectedAutonomousMode < 0.2 || simParams.ratioSelectedAutonomousMode > 1
+                error('Error: "simParams.ratioSelectedAutonomousMode" must be more than 0.2 and not more than 1 (specs: 0.2)');
+            end
+
+            % [L2active]
+            % Parameter that gives the possibility to reintroduce L2 in mode2
+            % By default (and specifications) is active in LTE and disabled in 5G
+            [simParams, varargin] = addNewParam(simParams, 'L2active', ~simParams.mode5G, 'Activate or De-activate L2 in mode2/mode4', 'bool', fileCfg, varargin{1});
+
+            % [averageSensingActive]
+            % Parameter that gives the possibility to reintroduce the average sensing in mode2
+            % By default (and specifications) is active in LTE and disabled in 5G
+            [simParams, varargin] = addNewParam(simParams, 'averageSensingActive', ~simParams.mode5G, 'Activate or De-activate the average sensing mode2/mode4', 'bool', fileCfg, varargin{1});
+
+            % This can be used with same effect as averageSensingActive to unify the two conditions
+            %     % [NsensingPeriod]
+            %     % Number of beacon periods during which performing sensing
+            %     [simParams,varargin{1}{1}]= addNewParam(simParams,'NsensingPeriod',10,'Number of beacon periods during which performing sensing','integer',fileCfg,varargin{1}{1});
+            %     if simParams.NsensingPeriod<=0
+            %         error('Error: "simParams.NsensingPeriod" must be larger than 0');
+            %     end
+
+            % [TsensingPeriod]
+            % Duration of the sensing period, in seconds
+            [simParams, varargin] = addNewParam(simParams, 'TsensingPeriod', 1, 'Duration of the sensing period, in seconds', 'double', fileCfg, varargin{1});
+            if simParams.TsensingPeriod <= 0
+                error('Error: "simParams.TsensingPeriod" must be larger than 0');
+            end
+
+            % [minRandValueMode4]
+            % Minimum duration keeping the same allocation
+            [simParams, varargin] = addNewParam(simParams, 'minRandValueMode4', -1, 'Minimum duration keeping the same allocation', 'integer', fileCfg, varargin{1});
+            if simParams.minRandValueMode4 ~= -1 && simParams.minRandValueMode4 <= 0
+                error('Error: "simParams.minRandValueMode4" must be more than 0');
+            end
+
+            % [maxRandValueMode4]
+            % Maximum duration keeping the same allocation
+            [simParams, varargin] = addNewParam(simParams, 'maxRandValueMode4', -1, 'Maximum duration keeping the same allocation', 'integer', fileCfg, varargin{1});
+            if simParams.maxRandValueMode4 ~= -1 && simParams.maxRandValueMode4 <= simParams.minRandValueMode4
+                error('Error: "simParams.maxRandValueMode4" must be larger than "simParams.minRandValueMode4"');
+            end
+
+            % [powerThresholdAutonomous]
+            % Minimum power threshold to consider a BR as occupied in dBm
+            [simParams, varargin] = addNewParam(simParams, 'powerThresholdAutonomous', -110, 'Minimum power threshold to consider a BR as occupied in Mode 4, in dBm', 'double', fileCfg, varargin{1});
+            if simParams.powerThresholdAutonomous / 2 < -64 || simParams.powerThresholdAutonomous / 2 > -1 || mod(simParams.powerThresholdAutonomous, 2) ~= 0
+                error('Error: "simParams.powerThresholdAutonomous" must be between -128 and -2, step 2 dB');
+            end
+            % From dBm to linear
+            simParams.powerThresholdAutonomous = db2pow(simParams.powerThresholdAutonomous - 30);
+
+            % [minSCIsinr]
+            % Minimum SINR for a SCI to be correctly decoded
+            [phyParams, varargin] = addNewParam(phyParams, 'minSCIsinr', 0, 'Minimum SINR for a SCI to be correctly decoded, in dB', 'double', fileCfg, varargin{1});
+            phyParams.minSCIsinr = db2pow(phyParams.minSCIsinr);
+
+            % [asynMode]
+            % Enables Asynchronous transmitters
+            [simParams, varargin] = addNewParam(simParams, 'asynMode', 0, 'Enables/Desable Asynchronous transmitters', 'integer', fileCfg, varargin{1});
+            if simParams.asynMode ~= 0 && simParams.asynMode ~= 1
+                error('Error: "simParams.asynMode" cannot different from 0 or 1');
+            end
+
+            % [percAsynUser]
+            % TODO
+            % if Asynchronous transmitters is active -> sets the percentage of
+            % Asynchronous users
+            if simParams.asynMode == 1
+                [simParams, varargin] = addNewParam(simParams, 'percAsynUser', 0.2, 'Percentage of asynchronous users', 'double', fileCfg, varargin{1});
+                if simParams.percAsynUser < 0 || simParams.percAsynUser > 1
+                    error('Error: "simParams.percAsynUser" must be within 0 and 1');
+                end
+            end
+
+            % [FDalgorithm]
+            % Enables different FD algorithm
+            [simParams, varargin] = addNewParam(simParams, 'FDalgorithm', 0, 'Enables FD algorithm', 'integer', fileCfg, varargin{1});
+            if simParams.FDalgorithm ~= 0 && phyParams.PDelta == Inf
+                error('Error: "phyParams.PDelta" must be defined');
+            end
+            if simParams.FDalgorithm ~= 0 && phyParams.duplexCV2X ~= "FD"
+                error('Error: "phyParams.duplexCV2X" must be "FD"');
+            end
+            if ismember(simParams.FDalgorithm, [1, 2]) && phyParams.cv2xNumberOfReplicasMax == 2
+                error('Error: "phyParams.cv2xNumberOfReplicasMax" must be equal to 1');
+            end
+            if ismember(simParams.FDalgorithm, [3, 4, 5, 6, 7, 8]) && phyParams.cv2xNumberOfReplicasMax ~= 2
+                error('Error: "phyParams.cv2xNumberOfReplicasMax" must be equal to 2');
+            end
+            if simParams.FDalgorithm ~= 0 && simParams.mode5G ~= 1
+                error('Error: "simParams.mode5G" must be equal to: 5G-V2X');
+            end
+
+            % [dynamicPDelta]
+            % Enables dynamic setting of PDelta
+            [simParams, varargin] = addNewParam(simParams, 'dynamicPDelta', 0, 'Enables dynamic setting of PDelta', 'integer', fileCfg, varargin{1});
+            if (simParams.dynamicPDelta == 1 && phyParams.duplexCV2X ~= "FD") || (simParams.dynamicPDelta == 1 && simParams.FDalgorithm == 0)
+                error('Error: "phyParams.duplexCV2X" must be "FD" or incompatible settings');
+            end
+
+            % [T1autonomousMode]
+            % Minimum time for the next allocation in ms
+            % For 5G, T1 is modelled as the sum of Tproc,0 and Tproc,1
+            % Tproc,1 must be smaller to 3, 2.5, or 2.25 ms for a SCS of 15, 30, 60 kHz, respectively.
+            % Tproc,0 is equivalent to 1 ms for a SCS of 15 kHz and 0.50 ms for the rest of SCS configurations.
+
+            if phyParams.muNumerology == 0    % 4G and 5G SCS=15
+                [simParams, varargin] = addNewParam(simParams, 'T1autonomousMode', 1, 'Minimum time for the next allocation in Autonomous Mode', 'integer', fileCfg, varargin{1});
+                if simParams.T1autonomousMode < 1 || simParams.T1autonomousMode > 4
+                    error('Error: "simParams.T1autonomousMode" must be between 1 and 4 in LTE and 5G SCS=15');
+                end
+            elseif phyParams.muNumerology == 1 || phyParams.muNumerology == 2 % 5G SCS=30 and 5G SCS=60
+                [simParams, varargin] = addNewParam(simParams, 'T1autonomousMode', 0.5, 'Minimum time for the next allocation in Autonomous Mode', 'double', fileCfg, varargin{1});
+                if (simParams.T1autonomousMode < 0.5 || simParams.T1autonomousMode > 3) && (phyParams.muNumerology == 1)
+                    error('Error: "simParams.T1autonomousMode" must be between 0.5 and 3 in 5G with SCS=30');
+                elseif (simParams.T1autonomousMode < 0.5 || simParams.T1autonomousMode > 2.75) && (phyParams.muNumerology == 2)
+                    error('Error: "simParams.T1autonomousMode" must be between 0.5 and 2.75 in 5G with SCS=60');
+                end
+            end
+
+            % [T2autonomousMode]
+            % Maximum time for the next allocation in ms
+            [simParams, varargin] = addNewParam(simParams, 'T2autonomousMode', 100, 'Maximum time for the next allocation in autonomous mode', 'integer', fileCfg, varargin{1});
+            if simParams.T2autonomousMode < 20 || simParams.T2autonomousMode > 100
+                error('Error: "simParams.T2autonomousMode" must be between 20 and 100 ms in LTE and 5G');
+            end
+
+            simParams.T1autonomousModeTTIs = simParams.T1autonomousMode * (2^phyParams.muNumerology);    % T1 in terms of TTIs
+            simParams.T2autonomousModeTTIs = simParams.T2autonomousMode * (2^phyParams.muNumerology);    % T2 in terms of TTIs
+    end
+
+    if ~ismember(simParams.BRAlgorithm, [constants.REASSIGN_BR_STD_MODE_4, constants.REASSIGN_BR_RAND_ALLOCATION])
+        if phyParams.BRoverlapAllowed
+            error('Partial overlap in the frequency domain implemented only for Mode 4 (alg. 18) or Random (101)');
+        end
+
+        if phyParams.cv2xNumberOfReplicasMax > 1
+            error('HHARQ implemented only for Mode 4 (alg. 18 and alg. 101)');
+        end
+    end
+
+    fprintf('\n');
 
 end

--- a/MatFilesInit/initiateBRAssignmentAlgorithm.m
+++ b/MatFilesInit/initiateBRAssignmentAlgorithm.m
@@ -24,7 +24,7 @@ function [simParams, phyParams, varargin] = initiateBRAssignmentAlgorithm(simPar
     % 101 -> RANDOM ALLOCATION
     % 102 -> ORDERED ALLOCATION (following X coordinate)
 
-    implementedAlgorithms = [constants.REASSIGN_BR_ALGORITHMS_CONTROLLED ; constants.REASSIGN_BR_ALOGRITHMS_AUTONOMOUS];
+    implementedAlgorithms = [constants.REASSIGN_BR_ALGORITHMS_CONTROLLED ; constants.REASSIGN_BR_ALGORITHMS_AUTONOMOUS];
 
     [simParams, varargin] = addNewParam(simParams, 'BRAlgorithm', constants.REASSIGN_BR_STD_MODE_4, 'Assignment algorithm', 'integer', fileCfg, varargin{1});
     if ~ismember(simParams.BRAlgorithm, implementedAlgorithms)

--- a/MatFilesPosition/addPosDelay.m
+++ b/MatFilesPosition/addPosDelay.m
@@ -1,29 +1,70 @@
-function [Xvehicle,Yvehicle,PosUpdateIndex] = addPosDelay(Xvehicle,Yvehicle,XvehicleReal,YvehicleReal,IDvehicle,indexNewVehicles,...
-    indexOldVehicles,indexOldVehiclesToOld,posUpdateAllVehicles,PosUpdatePeriod)
-% Update positions of vehicles in the current positioning update period
-% (PosUpdatePeriod)
-
-% Initialize temporary Xvehicle and Yvehicle
-Nvehicles = length(IDvehicle);
-XvehicleTemp = zeros(Nvehicles,1);
-YvehicleTemp = zeros(Nvehicles,1);
-
-% Position of new vehicles in the scenario immediately updated
-XvehicleTemp(indexNewVehicles) = XvehicleReal(indexNewVehicles);
-YvehicleTemp(indexNewVehicles) = YvehicleReal(indexNewVehicles);
-
-% Copy old coordinates to temporary Xvehicle and Yvehicle
-XvehicleTemp(indexOldVehicles) = Xvehicle(indexOldVehiclesToOld);
-YvehicleTemp(indexOldVehicles) = Yvehicle(indexOldVehiclesToOld);
-Xvehicle = XvehicleTemp;
-Yvehicle = YvehicleTemp;
-
-% Find index of vehicles in the scenario whose position will be updated
-PosUpdateIndex = find(posUpdateAllVehicles(IDvehicle)==PosUpdatePeriod);
-
-% Update positions
-Xvehicle(PosUpdateIndex) = XvehicleReal(PosUpdateIndex);
-Yvehicle(PosUpdateIndex) = YvehicleReal(PosUpdateIndex);
-
+function [XVehicleEstimated, YVehicleEstimated, XVehicleHistory, YVehicleHistory] = addPosDelay(XVehicle, YVehicle, XVehicleHistory, YVehicleHistory, timeNow, posDelay, posPacketLoss)
+    arguments (Input)
+        XVehicle (:, 1) double {mustBeNonNan, mustBeReal}
+        YVehicle (:, 1) double {mustBeNonNan, mustBeReal}
+        XVehicleHistory (:, :) cell
+        YVehicleHistory (:, :) cell
+        timeNow (1, 1) double {mustBeNonnegative}
+        posDelay (1, 1) double {mustBeNonnegative}
+        posPacketLoss (1, 1) double {mustBeNonnegative, mustBeLessThan(posPacketLoss, 1)}
+    end
+    arguments (Output)
+        XVehicleEstimated (:, 1) double {mustBeNonNan, mustBeReal}
+        YVehicleEstimated (:, 1) double {mustBeNonNan, mustBeReal}
+        XVehicleHistory (:, :) cell
+        YVehicleHistory (:, :) cell
+    end
+    % preconditions: inputs are equal length
+    % histories are cells of timetable (not timeseries, because timeseries
+    % will no longer be viewable in variable editor in a future release)
+    n_vehicles = numel(YVehicle);
+    assert(numel(XVehicle) == numel(YVehicle));
+    assert(numel(XVehicleHistory) == numel(YVehicleHistory));
+    assert(numel(XVehicle) == numel(XVehicleHistory));
+    time_now = seconds(timeNow);
+    % operations on cell arrays unfortunately cannot be vectorized
+    % it is faster to use forloop than to use cellfun
+    % initialise output
+    XVehicleEstimated = zeros(n_vehicles, 1);
+    YVehicleEstimated = zeros(n_vehicles, 1);
+    for i = 1:n_vehicles
+        % copy the data out first to avoid repeated indexing
+        this_vehicle_x_history = XVehicleHistory{i};
+        this_vehicle_y_history = YVehicleHistory{i};
+        % just in case
+        assert(isa(this_vehicle_x_history, 'timetable'));
+        assert(isa(this_vehicle_y_history, 'timetable'));
+        % there should only be one variable
+        assert(width(this_vehicle_x_history) == 1);
+        assert(width(this_vehicle_y_history) == 1);
+        % if the timetables are empty, always append
+        % else, flip coin for packet loss probability, if the inverse case is
+        % true, add to the history timetable
+        if isempty(this_vehicle_x_history) || binornd(1, 1 - posPacketLoss)
+            this_vehicle_x_history{time_now, 1} = XVehicle(i);
+            this_vehicle_y_history{time_now, 1} = YVehicle(i);
+            % timetables are value types, so we have to insert it back into the
+            % cell array
+            XVehicleHistory{i} = this_vehicle_x_history;
+            YVehicleHistory{i} = this_vehicle_y_history;
+        end
+        % find the best position snapshot
+        % for simplicity we find the index using the X position table
+        oldest_valid_snapshot_time = max(this_vehicle_x_history.Properties.RowTimes(this_vehicle_x_history.Properties.RowTimes <= seconds(timeNow - posDelay)));
+        if isempty(oldest_valid_snapshot_time)
+            oldest_snapshot = min(this_vehicle_x_history.Properties.RowTimes);
+            XVehicleEstimated(i) = table2array(this_vehicle_x_history(oldest_snapshot, 1));
+            YVehicleEstimated(i) = table2array(this_vehicle_y_history(oldest_snapshot, 1));
+        else
+            XVehicleEstimated(i) = table2array(this_vehicle_x_history(oldest_valid_snapshot_time, 1));
+            YVehicleEstimated(i) = table2array(this_vehicle_y_history(oldest_valid_snapshot_time, 1));
+            % delete rows that are older than the oldest valid snapshot
+            this_vehicle_x_history(this_vehicle_x_history.Properties.RowTimes < oldest_valid_snapshot_time, :) = [];
+            this_vehicle_y_history(this_vehicle_y_history.Properties.RowTimes < oldest_valid_snapshot_time, :) = [];
+            % timetables are value types, so we have to insert it back into the
+            % cell array
+            XVehicleHistory{i} = this_vehicle_x_history;
+            YVehicleHistory{i} = this_vehicle_y_history;
+        end
+    end
 end
-

--- a/MatFilesUtility/computeDistance.m
+++ b/MatFilesUtility/computeDistance.m
@@ -1,16 +1,7 @@
-function [positionManagement,stationManagement] = computeDistance (simParams,simValues,stationManagement,positionManagement)
-% Function derived dividing previous version in computeDistance and
-% computeNeighbors (version 5.6.0)
-
-
-% Compute distance matrix
+function [positionManagement] = computeDistance (positionManagement)
+% Operates on struct members XvehicleReal, YvehicleReal, XvehicleEstimated,
+% YvehiclesEstimated to populate struct members distanceReal,
+% distanceEstimated
 positionManagement.distanceReal = sqrt((positionManagement.XvehicleReal - positionManagement.XvehicleReal').^2+(positionManagement.YvehicleReal - positionManagement.YvehicleReal').^2);
-%if simParams.technology ~= 2 && ... % not only 11p
-if sum(stationManagement.vehicleState(stationManagement.activeIDs)==constants.V_STATE_LTE_TXRX)>0  && ...   
-    (simParams.posError95 || positionManagement.NgroupPosUpdate~=1) %LTE
-    positionManagement.distanceEstimated = sqrt((simValues.XvehicleEstimated - simValues.XvehicleEstimated').^2+(simValues.YvehicleEstimated - simValues.YvehicleEstimated').^2);
-else
-    positionManagement.distanceEstimated = positionManagement.distanceReal;
-end
-
+positionManagement.distanceEstimated = sqrt((positionManagement.XvehicleEstimated - positionManagement.XvehicleEstimated').^2+(positionManagement.YvehicleEstimated - positionManagement.YvehicleEstimated').^2);
 end

--- a/MatFilesUtility/computeNeighbors.m
+++ b/MatFilesUtility/computeNeighbors.m
@@ -14,23 +14,29 @@ function [positionManagement,stationManagement] = computeNeighbors (stationManag
 if sum(stationManagement.vehicleState(stationManagement.activeIDs)==constants.V_STATE_LTE_TXRX)>0
 %if simParams.technology~=2 % Not only 11p
     distanceReal_LTE = positionManagement.distanceReal;
+    distanceEstimated_LTE = positionManagement.distanceEstimated;
     % Vehicles from which the received power is below a minimum are set to an infinite distance
     %distanceReal_LTE(stationManagement.activeIDs,stationManagement.activeIDs) = distanceReal_LTE(stationManagement.activeIDs,stationManagement.activeIDs)./nonNegligibleReceivedPower;
     % Vehciles that are not LTE are set to an infinite distance
     distanceReal_LTE(:,(stationManagement.vehicleState(stationManagement.activeIDs)~=100))=Inf;
+    distanceEstimated_LTE(:,(stationManagement.vehicleState(stationManagement.activeIDs)~=100))=Inf;
     % The diagonal must be set to 0
     distanceReal_LTE(1:1+length(distanceReal_LTE(1,:)):end) = 0;
+    distanceEstimated_LTE(1:1+length(distanceEstimated_LTE(1,:)):end) = 0;
     % sort
     [neighborsDistanceLTE, neighborsIndexLTE] = sort(distanceReal_LTE,2);
+    [~, neighborsIndexLTE_Estimated] = sort(distanceEstimated_LTE,2);
     % remove the first element per each raw, which is self
     neighborsDistanceLTE(:,1) = [];
-    neighborsIndexLTE(:,1) = [];    
+    neighborsIndexLTE(:,1) = [];
+    neighborsIndexLTE_Estimated(:,1) = [];
     neighborsDistanceLTE_ofLTE = neighborsDistanceLTE(stationManagement.vehicleState(stationManagement.activeIDs)==100,:);
     neighborsIndexLTE_ofLTE = neighborsIndexLTE(stationManagement.vehicleState(stationManagement.activeIDs)==100,:);
     
     % Vehicles in order of distance
     %allNeighborsID = IDvehicle(neighborsIndexLTE);
     stationManagement.allNeighborsID = stationManagement.activeIDs(neighborsIndexLTE);
+    stationManagement.allNeighborsIDEstimated = stationManagement.activeIDs(neighborsIndexLTE_Estimated);
     
     % Vehicles in the maximum awareness range
     stationManagement.neighborsIDLTE = (neighborsDistanceLTE_ofLTE < phyParams.RawMaxCV2X) .*stationManagement.activeIDs(neighborsIndexLTE_ofLTE);

--- a/Tests/+v2xsim_tests/+unit/+position/test_addPosDelay.m
+++ b/Tests/+v2xsim_tests/+unit/+position/test_addPosDelay.m
@@ -1,0 +1,94 @@
+function tests = test_addPosDelay
+    % only include functions that begin with the name "test"
+    idx = cellfun(@(f) startsWith(func2str(f), 'test'), localfunctions);
+    fs = localfunctions;
+    tests = functiontests(fs(idx));
+end
+
+function testNoDelay(testCase)
+    % test that if the posDelay is 0, the positions should not be delayed at
+    % all, regardless of the time
+    for time_now = [0 1 100]
+        [X_real, Y_real] = mockVehiclePositionData(100);
+        [X_history, Y_history] = mockVehiclePositionHistory(100);
+        [X_est, Y_est, ~, ~] = addPosDelay(X_real, Y_real, X_history, Y_history, time_now, 0, 0);
+        verifyEqual(testCase, X_est, X_real);
+        verifyEqual(testCase, Y_est, Y_real);
+    end
+end
+
+function testFiniteDelayReturnsOldestDataForTimesBeforeDelay(testCase)
+    % for the edge case where posDelay > 0 and timeNow <= posDelay, assert that
+    % the positions returned is always the oldest one
+    posDelay = 3;
+    [X_init, Y_init] = mockVehiclePositionData(100);
+    [X_history, Y_history] = mockVehiclePositionHistory(100);
+    [~, ~, X_history, Y_history] = addPosDelay(X_init, Y_init, X_history, Y_history, 0, 3, 0);
+    for time_now = linspace(0.1, 2.9, 10)
+        [X_real, Y_real] = mockVehiclePositionData(100);
+        [X_est, Y_est, X_history, Y_history] = addPosDelay(X_real, Y_real, X_history, Y_history, time_now, posDelay, 0);
+        verifyEqual(testCase, X_est, X_init);
+        verifyEqual(testCase, Y_est, Y_init);
+    end
+end
+
+function testFiniteDelayReturnsDelayedData(testCase)
+    % eventually, when timeNow > posDelay, return snapshots of positions at least posDelay
+    % seconds ago
+    posDelay = 3;
+    X_real_cell = cell(6, 1);
+    Y_real_cell = cell(6, 1);
+    for i = 1:6
+        [X_t, Y_t] = mockVehiclePositionData(100);
+        X_real_cell{i} = X_t;
+        Y_real_cell{i} = Y_t;
+    end
+    [X_history, Y_history] = mockVehiclePositionHistory(100);
+    for time_now = 1:6
+        X_real = X_real_cell{time_now};
+        Y_real = Y_real_cell{time_now};
+        [X_est, Y_est, X_history, Y_history] = addPosDelay(X_real, Y_real, X_history, Y_history, time_now, posDelay, 0);
+        if time_now > 3
+            X_pos_delay_ago = X_real_cell{time_now - posDelay};
+            Y_pos_delay_ago = Y_real_cell{time_now - posDelay};
+            verifyEqual(testCase, X_est, X_pos_delay_ago);
+            verifyEqual(testCase, Y_est, Y_pos_delay_ago);
+        end
+    end
+end
+
+function testNonzeroPacketLossResultsInTimetablesOfVaryingHeights(testCase)
+    % When there is packet loss, the height of the history tables should not be
+    % the same. Test with 100 vehicles, 50% loss chance, 10 position updates.
+    % This test has a very, very small chance of producing a false failure.
+    % P(Binomial(100*10, 0.5)=0) = 9.33E-302
+    % If this test fails on you, you should probably take a break and ponder
+    % what did you do to offend the RNG machines of the universe.
+    posDelay = 3;
+    [X_history, Y_history] = mockVehiclePositionHistory(100);
+    for time_now = linspace(0, 5, 10)
+        [X_real, Y_real] = mockVehiclePositionData(100);
+        [~, ~, X_history, Y_history] = addPosDelay(X_real, Y_real, X_history, Y_history, time_now, posDelay, 0.5);
+    end
+    history_table_heights = unique(cellfun(@height, X_history));
+    verifyEqual(testCase, numel(history_table_heights) ~= 1, true);
+end
+
+function [X, Y] = mockVehiclePositionData(n_vehicles)
+    % creates a mock vehicle position data
+    arguments
+        n_vehicles (1, 1) double {mustBeInteger mustBePositive}
+    end
+    X = rand(n_vehicles, 1) .* 1000;
+    Y = rand(n_vehicles, 1) .* 1000;
+end
+
+function [X_history, Y_history] = mockVehiclePositionHistory(n_vehicles)
+    % creates mock vehicle position timetable (empty)
+    X_history = cell(n_vehicles, 1);
+    Y_history = cell(n_vehicles, 1);
+    for i = 1:n_vehicles
+        X_history{i} = timetable(Size = [0 1], VariableTypes = {'double'}, TimeStep = seconds(0.1));
+        Y_history{i} = timetable(Size = [0 1], VariableTypes = {'double'}, TimeStep = seconds(0.1));
+    end
+end


### PR DESCRIPTION
Dear V2Xsim maintainers,

This is the last feature-based pull request I would like you to review before I work on restoring full tracefile support.
In my research, I have been researching how centralized algorithms will suffer under increasing signalling delay and loss (of the vehicle position) to the gNB.

This update changes/adds the following parameters:
- `posDelay` can now be set to any arbitary number.
- `posPacketLoss` is a float that represents the probability that a position update packet to the gNB is lost.

This update changes/adds the following internal state variables:
- `positionManagement` now has additional struct members `XvehicleEstimated` `YvehicleEstimated` `XvehicleHistory` `YvehicleHistory`
- `XvehicleEstimated` and `YvehicleEstimated` are simply vectors of the gNB's last known position of the vehicles `posDelay` seconds ago. These are meant to be passed to BR algorithms that use vehicle positions to make allocation decisions.
- `XvehicleHistory` and `YvehicleHistory` are internal state variables for use by the `addPosDelay` function. They are a cell of timetables that represents the history of values. The reason why each timetable is in a separate cell is because each vehicle's update to the gNB is an independent coin flip, so the height of each timetable is different.
- `stationManagement` now has an additional struct member, `allNeighborsIDEstimated`. It is the same as `allNeighborsID` but using the estimated vehicle positions that is affected by `posDelay`, `posError95` and `posPacketLoss`
- `outputValues` now has an additional struct member, `meanPositionError`, that represents the cumulative mean error of the vehicle's real position vs apparent position to the gNB.

This update changes/adds the behavior of the following functions:
- All controlled BR algorithms that use the vehicle's position (Ordered, Finite Reuse, Maximum Reuse) will be fed this apparent position/neighbor info that is affected by  `posDelay`, `posError95` and `posPacketLoss`
- `computeNeighbors` also populates `stationManagement.allNeighborsIDEstimated`, explanation above

This update also contains the following refactors for maintainability:
- Created a members for the `constants` class, `REASSIGN_BR_ALGORITHMS_CONTROLLED` and `REASSIGN_BR_ALOGRITHMS_AUTONOMOUS` that is just a vector of controlled vs autonomous algorithm constants.
- Simplified the `initiateBRAssignmentAlgorithm` file to significantly reduce the amount of duplicate code (many of the controlled algorithms share the same parameters)

Finally, it also contains unit tests for the `addPosDelay` function.